### PR TITLE
Add timeouts for IAM user sync

### DIFF
--- a/iam_user_sync.service
+++ b/iam_user_sync.service
@@ -8,4 +8,6 @@ Environment="IAM_AUTHORIZED_GROUPS=@@IAM_AUTHORIZED_GROUPS@@"
 Environment="LOCAL_GROUPS=@@LOCAL_GROUPS@@"
 Environment="LOCAL_MARKER_GROUP=@@LOCAL_MARKER_GROUP@@"
 Environment="PATH=@@PATH@@"
+TimeoutStartSec=300
+TimeoutStopSec=120
 ExecStart=@@INSTALL_PREFIX@@/bin/iam_user_sync


### PR DESCRIPTION
Our IAM user sync script is a `Type=oneshot` systemd unit file, which means that default timeouts aren't applicable. In one instance, I found a script to have been hanging for over 3 days. This PR implements a 300s start limit, and a 120s stop limit — both of which are within the 10-minute window.