### PR TITLE
Misc fixes

### DIFF
--- a/iam_user_sync.cron
+++ b/iam_user_sync.cron
@@ -6,4 +6,4 @@ LOCAL_GROUPS="@@LOCAL_GROUPS@@"
 LOCAL_MARKER_GROUP="@@LOCAL_MARKER_GROUP@@"
 PATH="@@PATH@@"
 
-*/10 * * * * root @@INSTALL_PREFIX@@/bin/iam_user_sync
+*/30 * * * * root @@INSTALL_PREFIX@@/bin/iam_user_sync

--- a/iam_user_sync.service
+++ b/iam_user_sync.service
@@ -8,6 +8,6 @@ Environment="IAM_AUTHORIZED_GROUPS=@@IAM_AUTHORIZED_GROUPS@@"
 Environment="LOCAL_GROUPS=@@LOCAL_GROUPS@@"
 Environment="LOCAL_MARKER_GROUP=@@LOCAL_MARKER_GROUP@@"
 Environment="PATH=@@PATH@@"
-TimeoutStartSec=300
+TimeoutStartSec=1200
 TimeoutStopSec=120
 ExecStart=@@INSTALL_PREFIX@@/bin/iam_user_sync

--- a/iam_user_sync.sh
+++ b/iam_user_sync.sh
@@ -26,7 +26,7 @@ function get_remote_users() {
 
 function create_update_local_user() {
   set +e
-  id ${1} >/dev/null 2>&1 || useradd -m ${1}
+  id ${1} >/dev/null 2>&1 || useradd -m ${1} && chown -R ${1}:${1} /home/${1}
   usermod -G ${LOCAL_GROUPS},${LOCAL_MARKER_GROUP} ${1}
   set -e
 }

--- a/iam_user_sync.sh
+++ b/iam_user_sync.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -ex
 
+# Ensure non-zero exit codes aren't swallowed by sed pipes
+set -o pipefail
+
 SSH_AUTHORIZED_KEYS_DIR=${SSH_AUTHORIZED_KEYS_DIR:-/etc/ssh/authorized_keys}
 IAM_AUTHORIZED_GROUPS=${IAM_AUTHORIZED_GROUPS:-}
 LOCAL_GROUPS=${LOCAL_GROUPS:-}

--- a/iam_user_sync.timer
+++ b/iam_user_sync.timer
@@ -1,8 +1,8 @@
 [Unit]
-Description=Run iam_user_sync.service every 10 minutes
+Description=Run iam_user_sync.service every 30 minutes
 
 [Timer]
-OnCalendar=*:0/10
+OnCalendar=*:0/30
 Persistent=true
 
 [Install]


### PR DESCRIPTION
This PR contains several misc fixes.  Among them:

1. Run the script every 30 minutes instead of every 10, and timeout if the script takes longer than 20 minutes to run (instead of 3).  I've noticed that the script occasionally takes ~10 minutes or so to run on a t2.small instance running CoreOS.  I suspect we occasionally chew through CPU credits on the smaller t2 instances and the fact we have to run awscli via docker container on CoreOS doesn't help (starting containers is somewhat expensive when you're doing it many times in succession).
2. Set the `pipefail` option for bash.  Without this option, the exit code of the right-most pipeline command is always used, meaning a pipe to `sed` swallows any non-zero exit status of the left-hand command.  With pipefail enabled, a non-zero exit is propagated through the pipe.  This ensures if `aws iam get-group` fails, the non-zero exit propagates and the script fails-fast due to `set -e`.  I believe we had a spurious `aws iam get-group` failure on one of the ECS hosts, which was interpreted as no users being members of the IAM group in question (since sed would have swallowed the failure status without pipefail), and this caused user accounts to be removed and then re-added again on the next script invocation.  Unfortunately, this resulted in wonky home directory ownership (fixed in #3 below).
3. Run `chown -R <user>:<user> /home/<user>` after user creation.  This is a no-op if a user has never been added before.  However, if a user was previously added and removed and is then added again, it's possible their home directory could have invalid ownership.  This appears to have happened on one of our ECS cluster hosts, per what @suan described to me.