### PR TITLE
Drop local variable scoping as it swallows command return codes

### DIFF
--- a/iam_user_sync.sh
+++ b/iam_user_sync.sh
@@ -41,8 +41,8 @@ function delete_local_user() {
 }
 
 function gather_user_keys() {
-  local tmpfile=$(mktemp)
-  local key_ids=$(
+  tmpfile=$(mktemp)
+  key_ids=$(
     aws iam list-ssh-public-keys \
       --user-name ${1} \
       --query "SSHPublicKeys[?Status=='Active'].[SSHPublicKeyId]" \
@@ -68,10 +68,10 @@ function sync_accounts() {
     exit 1
   fi
 
-  local local_users=$(get_local_users)
-  local remote_users=$(get_remote_users)
-  local intersection=$(echo ${local_users} ${remote_users} | tr " " "\n" | sort | uniq -D | uniq)
-  local removed_users=$(echo ${local_users} ${intersection} | tr " " "\n" | sort | uniq -u)
+  local_users=$(get_local_users)
+  remote_users=$(get_remote_users)
+  intersection=$(echo ${local_users} ${remote_users} | tr " " "\n" | sort | uniq -D | uniq)
+  removed_users=$(echo ${local_users} ${intersection} | tr " " "\n" | sort | uniq -u)
 
   for user in ${remote_users}; do
     create_update_local_user ${user}


### PR DESCRIPTION
Today we had a brief period of time where an EC2 instance's profile credentials disappeared.  It seems this might have been a brief IAM service hiccup?

Anyway, during this run of the sync script, `aws iam get-group` returned non-zero but the script didn't fail-fast.

While troubleshooting, I discovered that declaring variables as `local` in bash actually swallows command return codes, thus bypassing `set -e`!!!

```bash
$ value=$(false)
$ echo $?
1

$ local value=$(false)
$ echo $?
0
```

I'm opting for the simple fix and removing the `local` scoping on the variables.  There might be a way to get this to work without swallowing exit values, but the sync script is so short that we don't need to worry about variable naming collisions anyway.