### PR TITLE
Prefer adduser to useradd when available

### DIFF
--- a/iam_user_sync.sh
+++ b/iam_user_sync.sh
@@ -26,7 +26,14 @@ function get_remote_users() {
 
 function create_update_local_user() {
   set +e
-  id ${1} >/dev/null 2>&1 || useradd -m ${1} && chown -R ${1}:${1} /home/${1}
+  if ! id ${1} >/dev/null 2>&1; then
+    if command -v adduser >/dev/null 2>&1; then
+      adduser ${1}
+    else
+      useradd -m ${1}
+    fi
+    chown -R ${1}:${1} /home/${1}
+  fi
   usermod -G ${LOCAL_GROUPS},${LOCAL_MARKER_GROUP} ${1}
   set -e
 }


### PR DESCRIPTION
The adduser command is supplied on Ubuntu, RedHat, and other popular distros and is usually the
recommended way to create new user accounts.  The useradd command is considered lower level and typically doesn't perform all of the "usual" setup for new accounts.  The only reason we were
using it is because CoreOS doesn't supply the adduser command.

This is needed for Ubuntu 16.04.  Without it, all of the added users are given `/bin/sh` as their shell instead of the system default.  We're _supposed_ to be able to override that behavior in /etc/default/useradd, but there's a bug in Ubuntu 16.04 that causes useradd to ignore `SHELL` params specified in that file.