### PR TITLE
Fix a bug with having a user in multiple authorized groups

### DIFF
--- a/iam_user_sync.sh
+++ b/iam_user_sync.sh
@@ -20,7 +20,7 @@ function get_remote_users() {
       --group-name ${group} \
       --query "Users[].[UserName]" \
       --output text \
-    | sed "s/\r//g"
+    | sed "s/\r//g" | sort | uniq
   done
 }
 

--- a/iam_user_sync.sh
+++ b/iam_user_sync.sh
@@ -20,8 +20,8 @@ function get_remote_users() {
       --group-name ${group} \
       --query "Users[].[UserName]" \
       --output text \
-    | sed "s/\r//g" | sort | uniq
-  done
+    | sed "s/\r//g"
+  done | sort | uniq
 }
 
 function create_update_local_user() {


### PR DESCRIPTION
If a user was part of two authorized IAM groups, their account was actually being **removed**.  The root cause is due to the shell hackery I used in order to get the intersection of two lists of strings (not something bash handles well): https://github.com/usertesting/aws-ec2-ssh/blob/bb62a324bb54eadb6b1ffe819c392410d0273460/iam_user_sync.sh#L80

To be honest, I'm very close to wanting to replace this IAM SSH syncing mechanism, but it hasn't required much maintenance, so I'm not sure.  I've never been thrilled by it, but it was a relatively simple first-attempt at using IAM SSH keys on our SSH hosts.